### PR TITLE
Update dot to synchronize with rustc's graphviz

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "dot"
-version = "0.1.4-dev"
+version = "0.2.0-dev"
 authors = ["The Rust Project Developers", "Graham Dennis <graham.dennis@gmail.com>"]
 description = "A library for generating Graphviz DOT language files for graphs."
 readme = "README.md"


### PR DESCRIPTION
There have been a lot of changes in the upstream graphviz crate,
which haven't made it down here. The two significant changes are
that the trait node and edges have been converted into associated
types, and that there's been a IntoCow trait added to simplify
some code. The rest of the changes were mainly synchronizing on
style.

This also bumps the version to 0.2.0 because it's a breaking change.